### PR TITLE
Initial `/place` controller

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,15 @@
 	<properties>
 		<java.version>21</java.version>
 	</properties>
+
+	<repositories>
+		<repository>
+			<id>google</id>
+			<name>google</name>
+			<url>https://maven.google.com</url>
+		</repository>
+	</repositories>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -64,6 +73,13 @@
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>com.google.maps</groupId>
+			<artifactId>google-maps-places</artifactId>
+			<version>0.25.0</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/mangalitsa/litsa/controller/PlaceController.java
+++ b/src/main/java/com/mangalitsa/litsa/controller/PlaceController.java
@@ -1,0 +1,32 @@
+package com.mangalitsa.litsa.controller;
+
+import com.mangalitsa.litsa.controller.model.PlaceResponse;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/place")
+public class PlaceController {
+
+    @GetMapping
+    public List<PlaceResponse> getPlaces(
+            // e.g. ?location=156,156&radius=5000&keyword=hello&keyword=world
+            // location = "156,156"
+            // radius = 5000
+            // keywords = { "hello", "world" }
+            @RequestParam String location,
+            @RequestParam int radius,
+            @Nullable
+            @RequestParam(name = "keyword", required = false)
+            List<String> keywords
+    ) {
+        // TODO: defer to service class
+        return List.of(new PlaceResponse("some_id", "a name"));
+    }
+
+}

--- a/src/main/java/com/mangalitsa/litsa/controller/model/PlaceResponse.java
+++ b/src/main/java/com/mangalitsa/litsa/controller/model/PlaceResponse.java
@@ -1,0 +1,10 @@
+package com.mangalitsa.litsa.controller.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record PlaceResponse(
+        @JsonProperty("google_place_id")
+        String googlePlaceId,
+        String name
+        // TODO: opening_hours
+) { }

--- a/src/test/java/com/mangalitsa/litsa/controller/PlaceControllerTest.java
+++ b/src/test/java/com/mangalitsa/litsa/controller/PlaceControllerTest.java
@@ -1,0 +1,35 @@
+package com.mangalitsa.litsa.controller;
+
+import com.mangalitsa.litsa.controller.model.PlaceResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class PlaceControllerTest {
+
+    private PlaceController placeController;
+
+    @BeforeEach
+    void setUp() {
+        placeController = new PlaceController();
+    }
+
+    @Test
+    void getPlaces() {
+        List<PlaceResponse> expected = List.of(new PlaceResponse("some_id", "a name"));
+
+        List<PlaceResponse> result = placeController.getPlaces(
+                "location",
+                1,
+                null
+        );
+
+        assertThat(result).isEqualTo(expected);
+    }
+}


### PR DESCRIPTION
Added an initial RestController for the ~~`/location`~~ `/place` endpoint.

Includes a stub DTO for `PlaceResponse` and an initial unit test.
