### PR TITLE
Initial `/favourites` controller

### DIFF
--- a/src/main/java/com/mangalitsa/litsa/controllers/FavouritesController.java
+++ b/src/main/java/com/mangalitsa/litsa/controllers/FavouritesController.java
@@ -1,0 +1,38 @@
+package com.mangalitsa.litsa.controllers;
+
+import com.mangalitsa.litsa.controllers.model.FavouriteRequest;
+import com.mangalitsa.litsa.controllers.model.FavouriteResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+@RestController
+@RequestMapping("/api/v1/favourites")
+public class FavouritesController {
+
+    @GetMapping
+    public List<FavouriteResponse> getFavourites() {
+        return emptyList(); //TODO
+    }
+
+    @GetMapping("/{id}")
+    public FavouriteResponse getFavourite(@PathVariable String id) {
+        return null; //TODO
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public FavouriteResponse addFavourite(@RequestBody FavouriteRequest body) {
+        return null; //TODO
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteFavourite(@PathVariable String id) {
+        // TODO
+    }
+
+}

--- a/src/main/java/com/mangalitsa/litsa/controllers/model/FavouriteRequest.java
+++ b/src/main/java/com/mangalitsa/litsa/controllers/model/FavouriteRequest.java
@@ -1,0 +1,9 @@
+package com.mangalitsa.litsa.controllers.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FavouriteRequest(
+        @JsonProperty("place_id")
+        String placeId
+        // TODO: other fields?
+) { }

--- a/src/main/java/com/mangalitsa/litsa/controllers/model/FavouriteResponse.java
+++ b/src/main/java/com/mangalitsa/litsa/controllers/model/FavouriteResponse.java
@@ -1,0 +1,11 @@
+package com.mangalitsa.litsa.controllers.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record FavouriteResponse(
+        String id,
+        String name,
+        @JsonProperty("place_id")
+        String placeId
+        // TODO
+) { }

--- a/src/test/java/com/mangalitsa/litsa/controllers/FavouritesControllerTest.java
+++ b/src/test/java/com/mangalitsa/litsa/controllers/FavouritesControllerTest.java
@@ -1,0 +1,50 @@
+package com.mangalitsa.litsa.controllers;
+
+import com.mangalitsa.litsa.controllers.model.FavouriteRequest;
+import com.mangalitsa.litsa.controllers.model.FavouriteResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class FavouritesControllerTest {
+
+    private FavouritesController favouritesController;
+
+    @BeforeEach
+    void setUp() {
+        favouritesController = new FavouritesController();
+    }
+
+    @Test
+    void getFavourites() {
+        var expected = emptyList();
+        var result = favouritesController.getFavourites();
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void getFavourite() {
+        FavouriteResponse expected = null;
+        var result = favouritesController.getFavourite("some_id");
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void addFavourite() {
+        FavouriteResponse expected = null;
+        var requestBody = new FavouriteRequest("some_place_id");
+        var result = favouritesController.addFavourite(requestBody);
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void deleteFavourite() {
+        String favouriteId = "some_id";
+        favouritesController.deleteFavourite(favouriteId);
+    }
+}


### PR DESCRIPTION
Stub controller for the `/favourites` endpoint, with some initial DTOs.

Closes #19
